### PR TITLE
Fixed foreman_param_lookup support with Foreman v1.10

### DIFF
--- a/app/services/foreman_param_lookup/any_classification.rb
+++ b/app/services/foreman_param_lookup/any_classification.rb
@@ -1,7 +1,31 @@
 class ForemanParamLookup::AnyClassification < Classification::ClassParam
+  include LookupKeysHelper
+  include HostsHelper
+
   def initialize args = { }
     super args
     @classes = args[:classes]
+  end
+
+  def enc
+    hash = @classes.map do |puppet_class|
+      lookup_keys   = overridable_lookup_keys(puppet_class, @host)
+      lookup_values = lookup_keys.map { |lookup_key|
+      
+        if lookup_key.use_puppet_default
+          value = lookup_key.default_value
+        else
+          lookup_value = @host.lookup_values.detect { |v| v.lookup_key_id == lookup_key.id }
+          value = lookup_value.value unless lookup_value.nil?
+        end
+
+        [lookup_key.key, value]
+      }.compact
+
+      [puppet_class.name, Hash[lookup_values]] unless lookup_values.empty?
+    end
+
+    Hash[hash.compact]
   end
 
   private


### PR DESCRIPTION
Now foreman_param_lookup also returns Smart Class Parameters values for classes not explicitly included by Foreman's ENC.

Fixes issue #2.
